### PR TITLE
Redirect: Only redirect GET. Save desired location

### DIFF
--- a/example/example.go
+++ b/example/example.go
@@ -22,7 +22,6 @@ const rootHTML = `<!doctype html><html><head>
 </body></html>`
 
 func handleRoot(w http.ResponseWriter, r *http.Request) {
-	log.Println("wtf")
 	if r.URL.Path != "/" {
 		log.Printf("root returning 404 for %s", r.URL.String())
 		http.NotFound(w, r)


### PR DESCRIPTION
Do not redirect POST. This could cause some undesired behaviour. Just fail.
This means the user should load some authenticated page before calling APIs.

Save the page we want to visit in #, and on the JavaScript side, save it
in sessionStorage. This should allow multiple tabs to be redirected BACK to
the page they were going to.