### PR TITLE
rm client secret: not used or needed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,4 @@ To run it yourself:
 
 1. Create a new Google Sign-In OAuth client ID and secret. [Follow Google's instructions to do this](https://developers.google.com/identity/sign-in/web/sign-in#before_you_begin).
 2. Configure the OAuth client to permit `https://YOURDOMAIN` as an *Authorized JavaScript origin* and `https://YOURDOMAIN/__start_signin` as an *Authorized redirect URI*.
-3. `CLIENT_ID=YOURID CLIENT_SECRET=YOURSECET go run github.com/evanj/googlesignin/example`
+3. `CLIENT_ID=YOURID go run github.com/evanj/googlesignin/example`

--- a/example/example.go
+++ b/example/example.go
@@ -55,8 +55,8 @@ func (s *server) handlePage(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func newServer(clientID string, clientSecret string) *server {
-	authenticator := googlesignin.New(clientID, clientSecret, "/")
+func newServer(clientID string) *server {
+	authenticator := googlesignin.New(clientID, "/")
 	authenticator.RedirectIfNotSignedIn = true
 
 	mux := http.NewServeMux()
@@ -85,12 +85,6 @@ func main() {
 		panic("must specify Google Client ID with environment variable " + clientIDEnvVar)
 	}
 
-	const clientSecretEnvVar = "CLIENT_SECRET"
-	clientSecret := os.Getenv(clientSecretEnvVar)
-	if clientSecret == "" {
-		panic("must specify Google Client ID with environment variable " + clientIDEnvVar)
-	}
-
-	s := newServer(clientID, clientSecret)
+	s := newServer(clientID)
 	log.Fatal(http.ListenAndServe(":"+port, s.handler))
 }

--- a/example/example_test.go
+++ b/example/example_test.go
@@ -12,7 +12,7 @@ import (
 
 // A demonstration of how to test handlers using googlesignin.
 func TestAuthenticatedRequest(t *testing.T) {
-	s := newServer(signintest.ClientID, signintest.ClientSecret)
+	s := newServer(signintest.ClientID)
 	testAuth := signintest.InsecureTestAuthenticator(s.authenticator)
 
 	r := httptest.NewRequest(http.MethodGet, "/page1", nil)

--- a/googlesignin.go
+++ b/googlesignin.go
@@ -136,7 +136,6 @@ type Authenticator struct {
 	CachedKeys KeySet
 
 	clientID     string
-	clientSecret string
 	signedInPath string
 	publicPaths  map[string]bool
 }
@@ -144,11 +143,11 @@ type Authenticator struct {
 // New creates a new Authenticator, configured with the provided OAuth configuration. The
 // middleware will serve the page to start the sign in publicly at signInPath. Once successful,
 // it will redirect back to signedInPath.
-func New(clientID string, clientSecret string, signedInPath string) *Authenticator {
+func New(clientID string, signedInPath string) *Authenticator {
 	return &Authenticator{
 		"", defaultSignInPath, false,
 		&cachedKeySet{googleJWKURL, nil, time.Time{}},
-		clientID, clientSecret, signedInPath,
+		clientID, signedInPath,
 		make(map[string]bool),
 	}
 }

--- a/private_test.go
+++ b/private_test.go
@@ -85,7 +85,7 @@ func TestCachedKeys(t *testing.T) {
 }
 
 func TestMakePublic(t *testing.T) {
-	a := New("clientid", "clientsecret", "/loggedin")
+	a := New("clientid", "/loggedin")
 	a.MakePublic("/")
 	a.MakePublic("/public")
 	a.MakePublic("/publicdir/")

--- a/public_test.go
+++ b/public_test.go
@@ -5,11 +5,10 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"testing"
 
 	"github.com/evanj/googlesignin"
 	"github.com/evanj/googlesignin/signintest"
-
-	"testing"
 )
 
 const insecureTestDomain = "example.com"
@@ -22,7 +21,7 @@ type fixture struct {
 
 func newFixture() *fixture {
 	f := &fixture{
-		googlesignin.New(signintest.ClientID, signintest.ClientSecret, "/loggedin"),
+		googlesignin.New(signintest.ClientID, "/loggedin"),
 		nil,
 	}
 	f.a.HostedDomain = insecureTestDomain

--- a/signintest/signintest.go
+++ b/signintest/signintest.go
@@ -12,10 +12,6 @@ import (
 // ClientID is a fake OAuth client ID to be used with googlesignin.Authenticator in tests.
 const ClientID = "insecure_test_client_id"
 
-// ClientSecret is a fake client secret that is not used. However this mirrors ClientID, so makes
-// using this package more readable.
-const ClientSecret = "insecure_test_client_secret"
-
 // generated with gopkg.in/square/go-jose.v2/jwk-keygen
 const insecurePrivateKey = `{"use":"sig","kty":"EC","crv":"P-256","alg":"ES256","x":"-YdsjSFTEqKWQn7ZjThmkhuDDSasgh3ACWmgFKlo_7w","y":"LejdIY1pMKjXRlf3lStziDpQGPOynW49uF_Jlymcaxg","d":"xK_dS2q20mgRrYFVlwcJHOlNWmVxneJyzWFO-CGZ0BE"}`
 const testKeyID = "testkeyid"


### PR DESCRIPTION
We will need this again if we want to do things on behalf of the signed
in user on the server, but to check that the user is signed in, we don't.
Simplifies the API slightly.