### PR TITLE
Support getting the access token and requesting extra scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,17 @@ This is particularly good for "internal applications" that should be available t
 
 ## Example
 
-The example is running at https://gosignin-demo.appspot.com/
+The example is running at https://gosignin-demo.appspot.com/ or [see the code](example/example.go).
 
 To run it yourself:
 
 1. Create a new Google Sign-In OAuth client ID and secret. [Follow Google's instructions to do this](https://developers.google.com/identity/sign-in/web/sign-in#before_you_begin).
 2. Configure the OAuth client to permit `https://YOURDOMAIN` as an *Authorized JavaScript origin* and `https://YOURDOMAIN/__start_signin` as an *Authorized redirect URI*.
 3. `CLIENT_ID=YOURID go run github.com/evanj/googlesignin/example`
+
+
+## Design Overview / Notes
+
+This calls the Google Sign-In JavaScript API and saves the resulting ID token and optionally the access token in a cookie. Malicious JavaScript running on the site could steal these cookie, but they are time limited, so this seems basically as good as setting a a session cookie. It might be slightly better to expose an endpoint that saves them as an encrypted blob in an HTTPOnly cookie.
+
+The Go handler requires these cookies to be set, and validates the ID token on each request. If it is invalid, permission is denied or it redirects to the sign in page. If the token can be refreshed, it is refreshed by the JavaScript, then it redirects back to the original page. The original URL is embedded in the sign in page's `#` hash, and is saved in `sessionStorage` if it needs to redirect to the sign in page.

--- a/public_test.go
+++ b/public_test.go
@@ -2,6 +2,8 @@
 package googlesignin_test
 
 import (
+	"bytes"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -91,11 +93,16 @@ func TestAuthenticatedHandler(t *testing.T) {
 	calledRequest = nil
 
 	// the sign in path must be public
+	f.a.ExtraScopes = "extra_scope"
 	r.URL.Path = "/__start_signin"
 	recorder = httptest.NewRecorder()
 	authenticatedHandler.ServeHTTP(recorder, r)
 	if calledRequest != nil || recorder.Code != http.StatusOK {
 		t.Error("expected succesful request for sign in:", recorder.Code)
+	}
+	body, _ := ioutil.ReadAll(recorder.Result().Body)
+	if !bytes.Contains(body, []byte("openid email extra_scope")) {
+		t.Error("sign in page should contain scopes", string(body))
 	}
 
 	r.URL.Path = "/other"


### PR DESCRIPTION
This allows this library to be used to authenticate server side requests
on behalf of the user.