### PR TITLE
Fail sign in page over HTTP unless explicitly permitted

### DIFF
--- a/example/example.go
+++ b/example/example.go
@@ -137,7 +137,7 @@ func main() {
 
 	s := newServer(clientID)
 	if *insecureCookies {
-		s.authenticator.InsecureCookies()
+		s.authenticator.PermitInsecureCookies()
 		log.Printf("warning: permitting insecure HTTP cookies")
 	}
 	log.Fatal(http.ListenAndServe(":"+port, s.handler))


### PR DESCRIPTION
This makes it easy to debug why localhost sign ins are not working. We mark
the cookie as "secure", so if you are using http://localhost it won't work.
This makes the request fail obviously with a useful message on the server.

Rename InsecureCookies -> PermitInsecureCookies() to make it clear it is
configuring the Authenticator.