### PR TITLE
Sign in page: Fix JS for redirecting with hash

### DIFF
--- a/googlesignin.go
+++ b/googlesignin.go
@@ -389,8 +389,8 @@ function init() {
 		function getRedirect() {
 			debugger;
 			const hash = window.location.hash;
-			if (hash[0] === "/") {
-				return hash;
+			if (hash.startsWith("#/")) {
+				return hash.substring(2);
 			}
 
 			const sessionRedirect = sessionStorage.getItem(sessionStorageKey);


### PR DESCRIPTION
If the user is already signed in but does not have our cookie for some
reason, we use the hash to redirect. It turns out the code was not parsing
it correctly. Fix it!