### PR TITLE
iap: Package for verifying requests from Identity-Aware Proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # Google Sign-In
 
-A Go HTTP middleware for the Google Sign-In web application JavaScript library.
+This library provides Go HTTP middleware to require Google Sign-In in a web application.
 
-Google currently recommends web applications use [their JavaScript library to implement "sign in with Google."](https://developers.google.com/identity/sign-in/web/) I was curious about this compares to the older OAuth redirect approach. This library tries to be as easy to use as possible, and implements secure defaults. It verifies ID tokens on the server side using Google's public keys and Square's JOSE library. It requires users to be logged in for all endpoints, except a list of endpoints that are explicitly public.
+Google currently recommends web applications use [their JavaScript library to implement "sign in with Google."](https://developers.google.com/identity/sign-in/web/) I was curious about this compares to the older OAuth redirect approach. This library tries to be as easy to use as possible, and implements secure defaults. It verifies ID tokens on the server side using Google's public keys and Square's JOSE library. It requires users to be logged in for all endpoints, except endpoints that are explicitly made public.
 
 This is particularly good for "internal applications" that should be available to users in your domain, but not the public. Just use the `RequiresSignIn` wrapper for all your endpoints, set the `HostedDomain` argument, and you are done! 
 
 
 ## Example
 
-The example is running at https://gosignin-demo.appspot.com/ or [see the code](example/example.go).
+The example is running at https://gosignin-demo.appspot.com/. It has a main page that is not protected, then three sub-pages that print the user's email address and additional access token information.
 
 To run it yourself:
 

--- a/iap/example/example.go
+++ b/iap/example/example.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"html/template"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/evanj/googlesignin/iap"
+)
+
+type iapTestCase struct {
+	Path        string
+	Description string
+}
+type iapValues struct {
+	Email     string
+	TestPages []iapTestCase
+}
+
+var iapTemplate = template.Must(template.New("page1").Parse(`<!doctype html><html><head>
+<title>Identity-Aware Proxy Test Page</title>
+</head>
+<body>
+<h1>Identity-Aware Proxy Test Page</h1>
+<p>Hello {{.Email}}! This page should be protected by Google's Identity-Aware Proxy.</p>
+
+<h2>Test URLs</h2>
+<p>The first one of these links should work. The rest should fail. See <a href="https://cloud.google.com/iap/docs/special-urls-and-headers-howto#testing_jwt_verification">Google's documentation for details</a>.</p>
+<ul>
+{{range .TestPages}}
+<li><a href="{{.Path}}">{{.Path}}</a>: {{.Description}}</li>
+{{end}}
+</ul>
+</body></html>`))
+
+func iapTestPage(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" {
+		http.NotFound(w, r)
+		return
+	}
+
+	email := iap.Email(r)
+
+	values := &iapValues{email, []iapTestCase{
+		// https://cloud.google.com/iap/docs/special-urls-and-headers-howto#testing_jwt_verification
+		{"NOT_SET", "A valid JWT."},
+		{"FUTURE_ISSUE", "Issue date is set in the future (not checked by go-jose: https://github.com/square/go-jose/issues/216)"},
+		{"PAST_EXPIRATION", "Expiration date is set in the past."},
+		{"ISSUER", "Incorrect issuer."},
+		{"AUDIENCE", "Incorrect audience."},
+		{"SIGNATURE", "Signed using an incorrect signer."},
+	}}
+
+	const prefix = "/_gcp_iap/secure_token_test/"
+	for i, test := range values.TestPages {
+		values.TestPages[i].Path = prefix + test.Path
+	}
+
+	err := iapTemplate.Execute(w, values)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func iapTokenTest(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/plain;charset=utf-8")
+	w.Write([]byte("requested: " + r.URL.String()))
+}
+
+func main() {
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+
+	const audienceEnvVar = "AUDIENCE"
+	audience := os.Getenv(audienceEnvVar)
+	if audience == "" {
+		panic("must set the expected IAP Audience with environment variable " + audienceEnvVar)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", iapTestPage)
+	mux.HandleFunc("/_gcp_iap/", iapTokenTest)
+
+	authenticatedHandler := iap.Required(audience, mux)
+	log.Fatal(http.ListenAndServe(":"+port, authenticatedHandler))
+}

--- a/iap/iap.go
+++ b/iap/iap.go
@@ -12,7 +12,7 @@ import (
 
 const jwtHeaderName = "x-goog-iap-jwt-assertion"
 const jwkURL = "https://www.gstatic.com/iap/verify/public_key-jwk"
-const Issuer = "https://cloud.google.com/iap"
+const issuer = "https://cloud.google.com/iap"
 
 type contextKey int
 
@@ -26,7 +26,7 @@ type middleware struct {
 
 func (m *middleware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	headerValue := r.Header.Get(jwtHeaderName)
-	claims, err := jwkkeys.ValidateGoogleClaims(m.cachedKeys, headerValue, m.audience, Issuer)
+	claims, err := jwkkeys.ValidateGoogleClaims(m.cachedKeys, headerValue, m.audience, issuer)
 	if err != nil {
 		log.Printf("ERROR: failed verifying JWT: %s", err.Error())
 		http.Error(w, "forbidden", http.StatusForbidden)

--- a/iap/iap.go
+++ b/iap/iap.go
@@ -1,0 +1,60 @@
+// Package iap provides HTTP middleware for Google Cloud's Identity-Aware Proxy.
+// See https://cloud.google.com/iap/docs/concepts-overview
+package iap
+
+import (
+	"context"
+	"log"
+	"net/http"
+
+	"github.com/evanj/googlesignin/jwkkeys"
+)
+
+const jwtHeaderName = "x-goog-iap-jwt-assertion"
+const jwkURL = "https://www.gstatic.com/iap/verify/public_key-jwk"
+const Issuer = "https://cloud.google.com/iap"
+
+type contextKey int
+
+const emailKey = contextKey(1)
+
+type middleware struct {
+	audience        string
+	originalHandler http.Handler
+	cachedKeys      jwkkeys.Set
+}
+
+func (m *middleware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	headerValue := r.Header.Get(jwtHeaderName)
+	claims, err := jwkkeys.ValidateGoogleClaims(m.cachedKeys, headerValue, m.audience, Issuer)
+	if err != nil {
+		log.Printf("ERROR: failed verifying JWT: %s", err.Error())
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
+	if claims.Email == "" {
+		log.Println("ERROR: no email claim")
+		http.Error(w, "forbidden", http.StatusForbidden)
+	}
+
+	ctxWithEmail := context.WithValue(r.Context(), emailKey, claims.Email)
+	rWithCtx := r.WithContext(ctxWithEmail)
+	m.originalHandler.ServeHTTP(w, rWithCtx)
+}
+
+// Required returns an http.Handler which ensures requests came from Google's Identity-Aware Proxy.
+// The handler will return an HTTP 403 Forbidden error to any request that does not have a valid
+// header, or if any error occurs while trying to validate the signed header.
+//
+// To see the possible values for audience, see:
+// https://cloud.google.com/iap/docs/signed-headers-howto#verify_the_jwt_payload
+func Required(audience string, handler http.Handler) http.Handler {
+	h := &middleware{audience, handler, jwkkeys.New(jwkURL)}
+	return h
+}
+
+// Email returns the email address of the user logged in via IAP, or panics. The request must have
+// been served by the HTTP middleware returned by Required.
+func Email(r *http.Request) string {
+	return r.Context().Value(emailKey).(string)
+}

--- a/iap/iap_test.go
+++ b/iap/iap_test.go
@@ -24,7 +24,7 @@ func TestNoHeader(t *testing.T) {
 
 	// TODO: Add fake header: it should work
 	const email = "u@example.com"
-	validToken := signintest.InsecureToken(audience, Issuer, email, "")
+	validToken := signintest.InsecureToken(audience, issuer, email, "")
 	r.Header.Set(jwtHeaderName, validToken)
 
 	recorder = httptest.NewRecorder()

--- a/iap/iap_test.go
+++ b/iap/iap_test.go
@@ -1,0 +1,35 @@
+package iap
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/evanj/googlesignin/signintest"
+)
+
+func TestNoHeader(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {}
+	const audience = "some_audience"
+	authenticatedHandler := Required(audience, http.HandlerFunc(handler))
+	authenticatedHandler.(*middleware).cachedKeys = signintest.InsecureKeys()
+
+	// No header: fails
+	recorder := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	authenticatedHandler.ServeHTTP(recorder, r)
+	if recorder.Code != http.StatusForbidden {
+		t.Error("expected Forbidden:", recorder.Code)
+	}
+
+	// TODO: Add fake header: it should work
+	const email = "u@example.com"
+	validToken := signintest.InsecureToken(audience, Issuer, email, "")
+	r.Header.Set(jwtHeaderName, validToken)
+
+	recorder = httptest.NewRecorder()
+	authenticatedHandler.ServeHTTP(recorder, r)
+	if recorder.Code != http.StatusOK {
+		t.Error("expected OK:", recorder.Code)
+	}
+}

--- a/jwkkeys/jwkkeys.go
+++ b/jwkkeys/jwkkeys.go
@@ -1,0 +1,169 @@
+// Package jwkkeys verifies JWTs using keys published at known URLs. This is mostly intended
+// as an internal package, but might be useful to others
+package jwkkeys
+
+import (
+	"encoding/json"
+	"errors"
+	"log"
+	"net/http"
+	"regexp"
+	"strconv"
+	"time"
+
+	jose "gopkg.in/square/go-jose.v2"
+	"gopkg.in/square/go-jose.v2/jwt"
+)
+
+const minCacheSeconds = 60
+
+var maxAgePattern = regexp.MustCompile(`(?:,|^)\s*(?i:max-age)\s*=\s*([^\s,]+)`)
+
+// ErrKeyNotFound is the error returned by KeySet.Get when the key ID is not found.
+var ErrKeyNotFound = errors.New("key not found")
+
+// GoogleExtraClaims stores the JSON for Google Sign-In's extra claims that are not included in the
+// basic OpenID claims.
+type GoogleExtraClaims struct {
+	// https://developers.google.com/identity/protocols/OpenIDConnect#hd-param
+	HostedDomain string `json:"hd,omitempty"`
+	Email        string `json:"email,omitempty"`
+}
+
+// CachedSet fetches and parses keys from a URL, caching them for as long as permitted.
+type CachedSet struct {
+	sourceURL string
+	keys      *jose.JSONWebKeySet
+	expires   time.Time
+}
+
+// Set retrieves keys in JWK format to validate tokens.
+type Set interface {
+	// Get returns the key matching keyID, or an error indicating what happened. Must return
+	// ErrKeyNotFound if the key does not exist.
+	Get(keyID string) (*jose.JSONWebKey, error)
+}
+
+func New(url string) *CachedSet {
+	return &CachedSet{url, nil, time.Time{}}
+}
+
+// Parses the max-age out of a Cache-Control header. Returns minCache if it cannot parse it, or
+// if the value is blow the minimum.
+// TODO: Use a real header parser that obeys all the various rules? E.g.
+// https://github.com/pquerna/cachecontrol
+//
+// See the specifications:
+// Cache-Control: https://tools.ietf.org/html/rfc7234#section-5.2
+// ABNF syntax: https://tools.ietf.org/html/rfc7234#appendix-C
+func parseMaxAge(cacheControl string) int {
+	// parse with a regexp; quoted strings could confuse this but it seems unlikely
+	matches := maxAgePattern.FindStringSubmatch(cacheControl)
+	if len(matches) == 0 {
+		return minCacheSeconds
+	}
+	if len(matches) != 2 {
+		panic("logic bug: must have exactly 1 capturing group")
+	}
+
+	parsedSeconds, err := strconv.Atoi(matches[1])
+	if err != nil {
+		return minCacheSeconds
+	}
+	if parsedSeconds < minCacheSeconds {
+		return minCacheSeconds
+	}
+	return parsedSeconds
+}
+
+func (c *CachedSet) Get(keyID string) (*jose.JSONWebKey, error) {
+	set, err := c.getKeySet()
+	if err != nil {
+		return nil, err
+	}
+
+	keys := set.Key(keyID)
+	if len(keys) > 0 {
+		return &keys[0], nil
+	}
+	return nil, ErrKeyNotFound
+}
+
+func (c *CachedSet) getKeySet() (*jose.JSONWebKeySet, error) {
+	if c.keys != nil && time.Now().Before(c.expires) {
+		return c.keys, nil
+	}
+
+	resp, err := http.Get(c.sourceURL)
+	if err != nil {
+		return nil, err
+	}
+
+	decoder := json.NewDecoder(resp.Body)
+	keys := &jose.JSONWebKeySet{}
+	err = decoder.Decode(keys)
+	err2 := resp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+	if err2 != nil {
+		return nil, err2
+	}
+
+	cacheSeconds := parseMaxAge(resp.Header.Get("Cache-Control"))
+	if cacheSeconds == minCacheSeconds {
+		log.Printf("warning: caching for minimum time: Cache-Control: %#v",
+			resp.Header.Get("Cache-Control"))
+	}
+	c.expires = time.Now().Add(time.Duration(cacheSeconds) * time.Second)
+	c.keys = keys
+	return c.keys, nil
+}
+
+// findKey returns the first key in token's headers that is stored in keys. Returns ErrKeyNotFound
+// if no keys match.
+func findKey(keys Set, token *jwt.JSONWebToken) (*jose.JSONWebKey, error) {
+	for _, header := range token.Headers {
+		key, err := keys.Get(header.KeyID)
+		if err == ErrKeyNotFound {
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+		return key, nil
+	}
+	return nil, ErrKeyNotFound
+}
+
+// ValidateGoogleClaims parses the JWT, verifies its signature nad claims, then returns the
+// Google-specific claims.
+func ValidateGoogleClaims(
+	keys Set, serializedJWT string, audience string, issuer string,
+) (*GoogleExtraClaims, error) {
+	token, err := jwt.ParseSigned(serializedJWT)
+	if err != nil {
+		return nil, err
+	}
+
+	// verify the signature and get the claims
+	key, err := findKey(keys, token)
+	if err != nil {
+		return nil, err
+	}
+	standardClaims := &jwt.Claims{}
+	extraClaims := &GoogleExtraClaims{}
+	err = token.Claims(key, standardClaims, extraClaims)
+	if err != nil {
+		return nil, err
+	}
+	err = standardClaims.Validate(jwt.Expected{
+		Audience: jwt.Audience{audience},
+		Issuer:   issuer,
+		Time:     time.Now(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return extraClaims, nil
+}

--- a/jwkkeys/jwkkeys.go
+++ b/jwkkeys/jwkkeys.go
@@ -44,6 +44,7 @@ type Set interface {
 	Get(keyID string) (*jose.JSONWebKey, error)
 }
 
+// New returns a new CachedSet that stores keys loaded from url.
 func New(url string) *CachedSet {
 	return &CachedSet{url, nil, time.Time{}}
 }
@@ -76,6 +77,7 @@ func parseMaxAge(cacheControl string) int {
 	return parsedSeconds
 }
 
+// Get returns the key matching keyID, or ErrNotFound if it could not be found.
 func (c *CachedSet) Get(keyID string) (*jose.JSONWebKey, error) {
 	set, err := c.getKeySet()
 	if err != nil {

--- a/jwkkeys/jwkkeys_test.go
+++ b/jwkkeys/jwkkeys_test.go
@@ -1,0 +1,96 @@
+package jwkkeys
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestParseMaxAge(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected int
+	}{
+		{"", minCacheSeconds},
+		{"max-age=123", 123},
+		{"public, max-age = 12345, must-revalidate, no-transform", 12345},
+		{"max-age=12345,public", 12345},
+		{" MAX-AGE = 12345 ", 12345},
+		{" MAX-age = 12345 technically invalid", 12345},
+
+		{"invalid max-age=123", minCacheSeconds},
+		{"invalid max-age=123", minCacheSeconds},
+		{"max-age=123.567", minCacheSeconds},
+		{"max-age=1", minCacheSeconds},
+		{"max-age=abc", minCacheSeconds},
+	}
+
+	for i, test := range tests {
+		output := parseMaxAge(test.input)
+		if output != test.expected {
+			t.Errorf("%d: parseMaxAge(%#v)=%#v; expected %#v", i, test.input, output, test.expected)
+		}
+	}
+}
+
+func TestCachedKeys(t *testing.T) {
+	responseBody := "{}"
+	handledRequest := false
+	keyHandler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Cache-Control", "public, max-age=12345, must-revalidate, no-transform")
+		w.Write([]byte(responseBody))
+		handledRequest = true
+	}
+	server := httptest.NewServer(http.HandlerFunc(keyHandler))
+	defer server.Close()
+
+	// Get an empty set of keys
+	cachedKeys := New(server.URL)
+	keys, err := cachedKeys.getKeySet()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(keys.Keys) != 0 {
+		t.Error(keys)
+	}
+	expiresDuration := cachedKeys.expires.Sub(time.Now())
+	if expiresDuration < 12340*time.Second {
+		t.Errorf("incorrect expires duration: %v ; expires %v", expiresDuration, cachedKeys.expires)
+	}
+	if !handledRequest {
+		t.Error("must have handled the request")
+	}
+
+	handledRequest = false
+	_, err = cachedKeys.getKeySet()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if handledRequest {
+		t.Error("response should have been cached")
+	}
+
+	// force expiry
+	cachedKeys.expires = time.Now().Add(-time.Second)
+	_, err = cachedKeys.getKeySet()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !handledRequest {
+		t.Error("response should have been refreshed")
+	}
+}
+
+func TestGoogleClaimsJSON(t *testing.T) {
+	// sanity check the json tags so we don't forget them
+	extraClaims := &GoogleExtraClaims{"domain", "email"}
+	output, err := json.Marshal(extraClaims)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(output) != `{"hd":"domain","email":"email"}` {
+		t.Error(string(output))
+	}
+}

--- a/private_test.go
+++ b/private_test.go
@@ -2,87 +2,8 @@
 package googlesignin
 
 import (
-	"encoding/json"
-	"net/http"
-	"net/http/httptest"
 	"testing"
-	"time"
 )
-
-func TestParseMaxAge(t *testing.T) {
-	tests := []struct {
-		input    string
-		expected int
-	}{
-		{"", minCacheSeconds},
-		{"max-age=123", 123},
-		{"public, max-age = 12345, must-revalidate, no-transform", 12345},
-		{"max-age=12345,public", 12345},
-		{" MAX-AGE = 12345 ", 12345},
-		{" MAX-age = 12345 technically invalid", 12345},
-
-		{"invalid max-age=123", minCacheSeconds},
-		{"invalid max-age=123", minCacheSeconds},
-		{"max-age=123.567", minCacheSeconds},
-		{"max-age=1", minCacheSeconds},
-		{"max-age=abc", minCacheSeconds},
-	}
-
-	for i, test := range tests {
-		output := parseMaxAge(test.input)
-		if output != test.expected {
-			t.Errorf("%d: parseMaxAge(%#v)=%#v; expected %#v", i, test.input, output, test.expected)
-		}
-	}
-}
-
-func TestCachedKeys(t *testing.T) {
-	responseBody := "{}"
-	handledRequest := false
-	keyHandler := func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Cache-Control", "public, max-age=12345, must-revalidate, no-transform")
-		w.Write([]byte(responseBody))
-		handledRequest = true
-	}
-	server := httptest.NewServer(http.HandlerFunc(keyHandler))
-	defer server.Close()
-
-	// Get an empty set of keys
-	cachedKeys := &cachedKeySet{server.URL, nil, time.Time{}}
-	keys, err := cachedKeys.getKeySet()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(keys.Keys) != 0 {
-		t.Error(keys)
-	}
-	expiresDuration := cachedKeys.expires.Sub(time.Now())
-	if expiresDuration < 12340*time.Second {
-		t.Errorf("incorrect expires duration: %v ; expires %v", expiresDuration, cachedKeys.expires)
-	}
-	if !handledRequest {
-		t.Error("must have handled the request")
-	}
-
-	handledRequest = false
-	_, err = cachedKeys.getKeySet()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if handledRequest {
-		t.Error("response should have been cached")
-	}
-
-	// force expiry
-	cachedKeys.expires = time.Now().Add(-time.Second)
-	_, err = cachedKeys.getKeySet()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !handledRequest {
-		t.Error("response should have been refreshed")
-	}
-}
 
 func TestMakePublic(t *testing.T) {
 	a := New("clientid", "/loggedin")
@@ -112,17 +33,5 @@ func TestMakePublic(t *testing.T) {
 		if a.isPublic(notPublicPath) {
 			t.Errorf("%d: isPublic(%#v) should be false", i, notPublicPath)
 		}
-	}
-}
-
-func TestClaimsJSON(t *testing.T) {
-	// sanity check the json tags so we don't forget them
-	extraClaims := &ExtraClaims{"domain", "email"}
-	output, err := json.Marshal(extraClaims)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(output) != `{"hd":"domain","email":"email"}` {
-		t.Error(string(output))
 	}
 }

--- a/signintest/signintest.go
+++ b/signintest/signintest.go
@@ -70,10 +70,13 @@ func parsePrivateKey() *jose.JSONWebKey {
 	return privateKey
 }
 
-func InsecureKeys() *staticKeySet {
+// InsecureKeys returns a key set containing an insecure test key. Should only be used in tests.
+func InsecureKeys() jwkkeys.Set {
 	return &staticKeySet{parsePrivateKey().Public()}
 }
 
+// InsecureToken returns a new token that is signed by a key in InsecureKeys. Should only be used
+// in tests.
 func InsecureToken(audience string, issuer string, email string, hostedDomain string) string {
 	privateKey := parsePrivateKey()
 	signingKey := jose.SigningKey{


### PR DESCRIPTION
The Google Cloud Identity-Aware Proxy uses extremely similar JWTs and keys
as Google Sign-In. Add support for verifying that requests come through the
proxy, and to get the email address from the signed header.