### PR TITLE
Trust X-Forwarded-Proto when checking for HTTPS

### DIFF
--- a/public_test.go
+++ b/public_test.go
@@ -141,6 +141,16 @@ func TestHTTPSSignIn(t *testing.T) {
 		t.Error("expected InternalServerError:", recorder.Code)
 	}
 
+	// HTTP with X-Forwarded-Proto: success
+	recorder = httptest.NewRecorder()
+	r.URL.Scheme = "http"
+	r.Header.Set("X-Forwarded-Proto", "https")
+	authenticatedHandler.ServeHTTP(recorder, r)
+	if recorder.Code != http.StatusOK {
+		t.Error("expected OK:", recorder.Code)
+	}
+	r.Header.Del("X-Forwarded-Proto")
+
 	// HTTP request with insecure set: works
 	f.a.PermitInsecureCookies()
 	recorder = httptest.NewRecorder()


### PR DESCRIPTION
Commit 404b7b8069 required HTTPS on the sign in page by default to try and
make configuration errors more obvious. It broke if the server is behind a
proxy that terminates TLS, which is probably pretty common. At least it is
the default on App Engine.