### PR TITLE
Sign in page: use window.location.replace to hide redirect

### DIFF
--- a/googlesignin.go
+++ b/googlesignin.go
@@ -256,7 +256,8 @@ function init() {
 				";path=/;samesite=lax;{{.SecureCookieOption}}max-age=" + response.expires_in;
 			document.cookie = "{{.AccessTokenCookieName}}=" + response.access_token +
 				";path=/;samesite=lax;{{.SecureCookieOption}}max-age=" + response.expires_in;
-			window.location = getRedirect();
+			// use replace so this redirect does not appear when the user clicks back
+			window.location.replace(getRedirect());
 		}
 
 		const initPromise = gapi.auth2.init({


### PR DESCRIPTION
When clicking back, the user would be taken to the sign in redirect which
then redirects them forward again. Hide this page from the history by using
location.replace.