### PR TITLE
iap: Add headers to the demo page; use go112; remove secret name

### DIFF
--- a/iap/example/app.yaml
+++ b/iap/example/app.yaml
@@ -1,3 +1,3 @@
-runtime: go111
+runtime: go112
 env_variables:
   AUDIENCE: /projects/446336824806/apps/goiap-demo

--- a/iap/example/deploy.sh
+++ b/iap/example/deploy.sh
@@ -4,4 +4,4 @@ set -euf -o pipefail
 # https://stackoverflow.com/a/246128
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-~/google-cloud-sdk/bin/gcloud app deploy --project=goiap-demo --promote "${DIR}/app_secret.yaml"
+~/google-cloud-sdk/bin/gcloud app deploy --project=goiap-demo --promote "${DIR}/app.yaml"


### PR DESCRIPTION
Output the IAP magic headers in the example page so they can be
inspected.

None of these files contain secrets; Rename them to clarify.