### PR TITLE
Dockerfile.signinproxy-example: Update to Debian 10; Latest Go, Pip

### DIFF
--- a/Dockerfile.signinproxy-example
+++ b/Dockerfile.signinproxy-example
@@ -2,24 +2,25 @@
 # docker build . -f Dockerfile.signinproxy-example
 
 # Go build image
-FROM golang:1.12.9-stretch AS go_builder
+FROM golang:1.13.6-buster AS go_builder
 COPY . /go/src/github.com/evanj/googlesignin
-RUN go get -v github.com/evanj/googlesignin/signinproxy && go install -v github.com/evanj/googlesignin/signinproxy
+WORKDIR /go/src/github.com/evanj/googlesignin
+RUN go build -o /go/bin/signinproxy -v ./signinproxy
 
 # Download pip: Debian's default Python 3 does not include pip
-FROM golang:1.12.9-stretch AS pip_downloader
-RUN curl --location https://github.com/pypa/pip/archive/19.2.3.tar.gz | tar -xvzf - --directory=/
+FROM golang:1.13.6-buster AS pip_downloader
+RUN curl --location https://github.com/pypa/pip/archive/19.3.1.tar.gz | tar -xvzf - --directory=/
 
 # Download Python dependencies
 # We save about ~13 MiB in image size by NOT creating a virtualenv
-FROM gcr.io/distroless/python3:debug AS py_dependencies
-COPY --from=pip_downloader /pip-19.2.3 /pip
+FROM gcr.io/distroless/python3-debian10:latest AS py_dependencies
+COPY --from=pip_downloader /pip-19.3.1 /pip
 COPY signinproxy/example/requirements.txt /
 ENV PYTHONPATH=/pip/src
 RUN python3 -m pip install -r /requirements.txt --target=/app
 
 # Runtime image
-FROM gcr.io/distroless/python3
+FROM gcr.io/distroless/python3-debian10:latest
 COPY --from=go_builder /go/bin/signinproxy /
 COPY --from=py_dependencies /app /app
 COPY signinproxy/example/*.py /app


### PR DESCRIPTION
The big update here is moving from Debian 9 -> Debian 10. Also update
Go and pip. It seems to work!