### PR TITLE
Use new Google Identity / Sign In With Google API

### DIFF
--- a/example/app.yaml
+++ b/example/app.yaml
@@ -1,4 +1,4 @@
-runtime: go113
+runtime: go116
 
 handlers:
 - url: /.*

--- a/example/example.go
+++ b/example/example.go
@@ -4,7 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"html/template"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/url"
@@ -15,26 +15,25 @@ import (
 
 const googleTokenInfoURL = "https://oauth2.googleapis.com/tokeninfo"
 
-const rootHTML = `<!doctype html><html><head>
-<title>Google Sign-In Example</title>
+var rootTemplate = template.Must(template.New("root").Parse(`<!doctype html><html><head>
+<title>Sign In With Google Example</title>
 </head>
 <body>
-<h1>Google Sign-In Example</h1>
-<p>This is an example Google Sign-In application, using <a href="https://github.com/evanj/googlesignin">github.com/evanj/googlesignin</a>. This page is public, but the other pages require you to log in:</p>
+<h1>Sign In With Google Example</h1>
+<p>This is an example of using Sign In With Google, via the <a href="https://github.com/evanj/googlesignin">github.com/evanj/googlesignin</a> library. This page is public, but the other pages require you to log in:</p>
 <ul>
 <li><a href="/page1">Page 1</a></li>
 <li><a href="/page2">Page 2</a></li>
-<li><a href="/tokeninfo">Show access token info</a></li>
+<li><a href="/tokeninfo">Show ID token info</a></li>
+{{if .LoggedIn}}
+<li><a href="{{.SignOutPath}}">Sign Out</a></li>
+{{end}}
 </ul>
-</body></html>`
+</body></html>`))
 
-func handleRoot(w http.ResponseWriter, r *http.Request) {
-	if r.URL.Path != "/" {
-		log.Printf("root returning 404 for %s", r.URL.String())
-		http.NotFound(w, r)
-		return
-	}
-	w.Write([]byte(rootHTML))
+type rootValues struct {
+	LoggedIn    bool
+	SignOutPath string
 }
 
 type pageValues struct {
@@ -42,7 +41,7 @@ type pageValues struct {
 	TokenInfo string
 }
 
-var pageTemplate = template.Must(template.New("page1").Parse(`<!doctype html><html><head>
+var pageTemplate = template.Must(template.New("page").Parse(`<!doctype html><html><head>
 <title>Google Sign-In Page</title>
 </head>
 <body>
@@ -62,6 +61,25 @@ type server struct {
 	tokenInfoURL  string
 }
 
+func (s *server) handleRoot(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" {
+		log.Printf("returning 404 (NotFound) for %s", r.URL.String())
+		http.NotFound(w, r)
+		return
+	}
+	if r.Method != http.MethodGet {
+		log.Printf("returning 405 (MethodNotAllowed) for %s", r.URL.String())
+		http.Error(w, "URL only supports GET", http.StatusMethodNotAllowed)
+		return
+	}
+
+	values := rootValues{s.authenticator.IsSignedIn(r), s.authenticator.SignOutPath}
+	err := rootTemplate.Execute(w, values)
+	if err != nil {
+		panic(err)
+	}
+}
+
 func (s *server) handlePage(w http.ResponseWriter, r *http.Request) {
 	values := &pageValues{s.authenticator.MustGetEmail(r), ""}
 	err := pageTemplate.Execute(w, values)
@@ -70,18 +88,18 @@ func (s *server) handlePage(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (s *server) accessTokenPage(w http.ResponseWriter, r *http.Request) {
-	accessToken, err := s.authenticator.GetAccessToken(r)
+func (s *server) idTokenPage(w http.ResponseWriter, r *http.Request) {
+	validatedToken, err := s.authenticator.GetIDToken(r)
 	if err != nil {
 		panic(err)
 	}
 	params := url.Values{}
-	params.Set("access_token", accessToken)
+	params.Set("id_token", validatedToken.IDToken)
 	resp, err := http.Get(s.tokenInfoURL + "?" + params.Encode())
 	if err != nil {
 		panic(err)
 	}
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	err2 := resp.Body.Close()
 	if err != nil {
 		panic(err)
@@ -90,7 +108,7 @@ func (s *server) accessTokenPage(w http.ResponseWriter, r *http.Request) {
 		panic(err2)
 	}
 	if resp.StatusCode != http.StatusOK {
-		panic(fmt.Sprintf("failed response code: %d", resp.StatusCode))
+		panic(fmt.Sprintf("failed response code: %d; body: %s", resp.StatusCode, string(body)))
 	}
 
 	values := &pageValues{s.authenticator.MustGetEmail(r), string(body)}
@@ -101,15 +119,15 @@ func (s *server) accessTokenPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func newServer(clientID string) *server {
-	authenticator := googlesignin.New(clientID, "/")
+	authenticator := googlesignin.New(clientID)
 	authenticator.RedirectIfNotSignedIn = true
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("/", handleRoot)
 	s := &server{authenticator, nil, googleTokenInfoURL}
+	mux.HandleFunc("/", s.handleRoot)
 	mux.HandleFunc("/page1", s.handlePage)
 	mux.HandleFunc("/page2", s.handlePage)
-	mux.HandleFunc("/tokeninfo", s.accessTokenPage)
+	mux.HandleFunc("/tokeninfo", s.idTokenPage)
 
 	s.handler = authenticator.RequireSignIn(mux)
 	authenticator.MakePublic("/")
@@ -119,9 +137,30 @@ func newServer(clientID string) *server {
 	return s
 }
 
+type httpStatusRecorder struct {
+	http.ResponseWriter
+	status int
+}
+
+func (h *httpStatusRecorder) WriteHeader(status int) {
+	h.status = status
+	h.ResponseWriter.WriteHeader(status)
+}
+
+func addLogMiddleware(handler http.Handler) http.Handler {
+	logHandler := func(w http.ResponseWriter, r *http.Request) {
+		wrappedWriter := &httpStatusRecorder{w, http.StatusOK}
+		handler.ServeHTTP(wrappedWriter, r)
+		log.Printf("%s %s: code %d", r.Method, r.URL.Path, wrappedWriter.status)
+	}
+	return http.HandlerFunc(logHandler)
+}
+
 func main() {
 	insecureCookies := flag.Bool("insecureCookies", false,
 		"Allow sending cookies over HTTP; use for localhost testing")
+	verbose := flag.Bool("verbose", false,
+		"Log all HTTP requests")
 	flag.Parse()
 
 	port := os.Getenv("PORT")
@@ -138,7 +177,13 @@ func main() {
 	s := newServer(clientID)
 	if *insecureCookies {
 		s.authenticator.PermitInsecureCookies()
-		log.Printf("warning: permitting insecure HTTP cookies")
+		log.Println("warning: permitting insecure HTTP cookies")
 	}
-	log.Fatal(http.ListenAndServe(":"+port, s.handler))
+
+	handler := s.handler
+	if *verbose {
+		handler = addLogMiddleware(handler)
+		log.Println("enabling verbose logging")
+	}
+	log.Fatal(http.ListenAndServe(":"+port, handler))
 }

--- a/example/example_test.go
+++ b/example/example_test.go
@@ -30,10 +30,10 @@ func TestAuthenticatedRequest(t *testing.T) {
 
 func TestTokenInfo(t *testing.T) {
 	// Configure a fake tokeninfo server
-	accessTokenParam := ""
+	idTokenParam := ""
 	const tokenInfoResponse = "token_info_response"
 	tokenInfoServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		accessTokenParam = r.URL.Query().Get("access_token")
+		idTokenParam = r.URL.Query().Get("id_token")
 		w.Write([]byte(tokenInfoResponse))
 	}))
 	defer tokenInfoServer.Close()
@@ -53,7 +53,7 @@ func TestTokenInfo(t *testing.T) {
 	if !bytes.Contains(body, []byte(tokenInfoResponse)) {
 		t.Error("Body does not contain tokeninfo response:", string(body))
 	}
-	if accessTokenParam != "fake_access_token" {
-		t.Error("incorrect access token param:", accessTokenParam)
+	if idTokenParam == "" {
+		t.Error("should have sent ID token, was empty")
 	}
 }

--- a/iap/iap.go
+++ b/iap/iap.go
@@ -36,18 +36,18 @@ func (m *middleware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	headerValue := r.Header.Get(jwtHeaderName)
-	claims, err := jwkkeys.ValidateGoogleClaims(m.cachedKeys, headerValue, m.audience, issuer)
+	validatedToken, err := jwkkeys.ValidateGoogleClaims(m.cachedKeys, headerValue, m.audience, issuer)
 	if err != nil {
 		log.Printf("ERROR: failed verifying JWT: %s", err.Error())
 		http.Error(w, "forbidden", http.StatusForbidden)
 		return
 	}
-	if claims.Email == "" {
+	if validatedToken.GoogleClaims.Email == "" {
 		log.Println("ERROR: no email claim")
 		http.Error(w, "forbidden", http.StatusForbidden)
 	}
 
-	ctxWithEmail := context.WithValue(r.Context(), emailKey{}, claims.Email)
+	ctxWithEmail := context.WithValue(r.Context(), emailKey{}, validatedToken.GoogleClaims.Email)
 	rWithCtx := r.WithContext(ctxWithEmail)
 	m.originalHandler.ServeHTTP(w, rWithCtx)
 }

--- a/private_test.go
+++ b/private_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestMakePublic(t *testing.T) {
-	a := New("clientid", "/loggedin")
+	a := New("clientid")
 	a.MakePublic("/")
 	a.MakePublic("/public")
 	a.MakePublic("/publicdir/")

--- a/public_test.go
+++ b/public_test.go
@@ -23,7 +23,7 @@ type fixture struct {
 
 func newFixture() *fixture {
 	f := &fixture{
-		googlesignin.New(signintest.ClientID, "/loggedin"),
+		googlesignin.New(signintest.ClientID),
 		nil,
 	}
 	f.a.HostedDomain = insecureTestDomain
@@ -73,7 +73,7 @@ func TestAuthenticatedHandler(t *testing.T) {
 	recorder = httptest.NewRecorder()
 	authenticatedHandler.ServeHTTP(recorder, r)
 	location := recorder.Header().Get("Location")
-	if calledRequest != nil || !(recorder.Code == http.StatusSeeOther && location == "/__start_signin#/hello?param=1") {
+	if calledRequest != nil || !(recorder.Code == http.StatusSeeOther && location == "/__start_signin") {
 		t.Error("expected redirect:", recorder.Code, location)
 	}
 	postR := httptest.NewRequest(http.MethodPost, "/hello", nil)
@@ -93,7 +93,6 @@ func TestAuthenticatedHandler(t *testing.T) {
 	calledRequest = nil
 
 	// the sign in path must be public
-	f.a.ExtraScopes = "extra_scope"
 	r.URL.Scheme = "https"
 	r.URL.Path = "/__start_signin"
 	recorder = httptest.NewRecorder()
@@ -102,8 +101,8 @@ func TestAuthenticatedHandler(t *testing.T) {
 		t.Error("expected succesful request for sign in:", recorder.Code)
 	}
 	body, _ := ioutil.ReadAll(recorder.Result().Body)
-	if !bytes.Contains(body, []byte("openid email extra_scope")) {
-		t.Error("sign in page should contain scopes", string(body))
+	if !bytes.Contains(body, []byte("https://accounts.google.com/gsi/client")) {
+		t.Error("sign in page should load JS library", string(body))
 	}
 
 	r.URL.Path = "/other"

--- a/serviceaccount/serviceaccount.go
+++ b/serviceaccount/serviceaccount.go
@@ -227,9 +227,9 @@ func NewAuthenticator(audience string) *Authenticator {
 
 // ValidateToken returns the identity that issued this token (sub), or an error if it is not valid.
 func (a *Authenticator) ValidateToken(jwt string) (string, error) {
-	claims, err := jwkkeys.ValidateGoogleClaims(a.cachedKeys, jwt, a.audience, jwkkeys.GoogleIssuers)
+	validatedToken, err := jwkkeys.ValidateGoogleClaims(a.cachedKeys, jwt, a.audience, jwkkeys.GoogleIssuers)
 	if err != nil {
 		return "", err
 	}
-	return claims.Email, nil
+	return validatedToken.GoogleClaims.Email, nil
 }

--- a/signinproxy/signinproxy.go
+++ b/signinproxy/signinproxy.go
@@ -156,7 +156,7 @@ func main() {
 	log.Printf("starting proxy server listening on %s", listen)
 	proxy := httputil.NewSingleHostReverseProxy(parsedDestination)
 
-	authenticator := googlesignin.New(clientID, "/")
+	authenticator := googlesignin.New(clientID)
 	authenticator.RedirectIfNotSignedIn = true
 	authenticator.HostedDomain = hostedDomain
 	authenticatedProxy := authenticator.RequireSignIn(proxy)

--- a/signintest/signintest.go
+++ b/signintest/signintest.go
@@ -30,7 +30,7 @@ func (r *RequestAuthenticator) InsecureMakeAuthenticated(
 	request *http.Request, email string,
 ) *http.Request {
 	idToken := InsecureToken(ClientID, jwkkeys.GoogleIssuers[0], email, r.authenticator.HostedDomain)
-	return googlesignin.InsecureMakeAuthenticated(request, idToken, "fake_access_token")
+	return googlesignin.InsecureMakeAuthenticated(request, idToken)
 }
 
 type staticKeySet struct {


### PR DESCRIPTION
Google has changed its preferred authentication API yet again. Update
the package to use it. Unfortunately, this does not provide access
tokens, so it can't be used with Google APIs. I'm going to add a
classic OAuth2 implementation to this package for those uses.